### PR TITLE
Use a single state for settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,17 +39,11 @@ const App: React.FC = () => {
   });
 
   useEffect(() => {
-    const storedUsers = JSON.parse(localStorage.getItem('githubUsers') || '[]');
-    const storedGithubToken = localStorage.getItem('githubToken');
-    const storedUserName = localStorage.getItem('userName');
-    const storedGithubOrg = localStorage.getItem('githubOrg');
-
-    setSettings({
-      users: storedUsers || [],
-      githubToken: storedGithubToken || '',
-      userName: storedUserName || '',
-      githubOrg: storedGithubOrg || ''
-    });
+    const storedSettings = JSON.parse(localStorage.getItem('settings') || '{}');
+    setSettings(prev => ({
+      ...prev,
+      ...storedSettings
+    }));
   }, []);
 
   const resetState = () => {

--- a/src/UserSetting.tsx
+++ b/src/UserSetting.tsx
@@ -37,7 +37,7 @@ const UserSetting: React.FC<{
   };
 
   const handleClose = async () => {
-    localStorage.setItem('githubSettings', JSON.stringify(settings));
+    localStorage.setItem('settings', JSON.stringify(settings));
     checkForChanges();
     setShow(false);
   }
@@ -46,7 +46,7 @@ const UserSetting: React.FC<{
     if (onModalOpen) onModalOpen();
     setChangesMade(false);
 
-    const storedSettings = JSON.parse(localStorage.getItem('githubSettings') || '{}');
+    const storedSettings = JSON.parse(localStorage.getItem('settings') || '{}');
     setPrevStoredUsers(storedSettings.users || []);
     setPrevStoredGithubToken(storedSettings.githubToken || '');
     setPrevStoredUserName(storedSettings.userName || '');


### PR DESCRIPTION
Closes #8 

To convert prev settings:

```js
(() => {
  // Retrieve individual settings from local storage
  const githubUsers = JSON.parse(localStorage.getItem('githubUsers') || '[]');
  const githubToken = localStorage.getItem('githubToken') || '';
  const userName = localStorage.getItem('userName') || '';
  const githubOrg = localStorage.getItem('githubOrg') || '';

  // Create the consolidated settings object
  const newSettings = {
    users: githubUsers,
    githubToken: githubToken,
    userName: userName,
    githubOrg: githubOrg
  };

  // Store the consolidated settings in local storage
  localStorage.setItem('settings', JSON.stringify(newSettings));

  // Optionally, clear the old individual settings from local storage
  localStorage.removeItem('githubUsers');
  localStorage.removeItem('githubToken');
  localStorage.removeItem('userName');
  localStorage.removeItem('githubOrg');

  console.log('Settings converted and saved in the new format!');
})();
```